### PR TITLE
Changes the grammar, OpCode::Call and cleaned up some code.

### DIFF
--- a/src/lib/config_ast.rs
+++ b/src/lib/config_ast.rs
@@ -42,7 +42,7 @@ pub enum Expr {
     FuncDef {
         span: Span,
         name: Span,
-        args_list: Box<Expr>,
+        args_list: Vec<Span>,
         body: Box<Expr>,
     },
     Call {

--- a/src/lib/vm.rs
+++ b/src/lib/vm.rs
@@ -1,4 +1,4 @@
-use crate::compiler::{compiler, Ast, OpCode};
+use crate::compiler::{ compiler, Ast, OpCode };
 use core::panic;
 use lrlex::DefaultLexeme;
 use lrpar::NonStreamingLexer;
@@ -14,10 +14,21 @@ pub enum Types {
 #[derive(Debug, Clone)]
 pub struct Function {
     pub name: String,
-    pub args: Vec<OpCode>,
+    pub locals: Option<Vec<Types>>,
+    pub args: Vec<String>,
     pub prog: Vec<OpCode>,
 }
 
+impl Function {
+    fn new() -> Function {
+        Function {
+            args: Vec::new(),
+            prog: Vec::new(),
+            locals: Some(Vec::new()),
+            name: String::new(),
+        }
+    }
+}
 impl Types {
     fn pretty(&self) -> String {
         match *self {
@@ -38,7 +49,7 @@ impl fmt::Display for Types {
 fn vm(
     prog: Vec<OpCode>,
     locals: &mut Vec<Types>,
-    functions: &mut Vec<Function>,
+    functions: &mut Vec<Function>
 ) -> Result<Vec<Types>, String> {
     if prog.is_empty() {
         return Err("Cannot execute empty program".to_string());
@@ -98,17 +109,9 @@ fn vm(
                     // search for the user-defined function
                     let func = functions.iter().find(|f| f.name == *label);
                     if let Some(func) = func {
-                        //to pass args in local
-                        let mut arg_values = Vec::new();
-                        //just iterate indexes?
-                        for arg in &func.args {
-                            let val = stack.pop().unwrap();
-                            arg_values.push(val);
-                        }
-
-                        arg_values.reverse();
-                        // execute the function
-                        let result = vm(func.prog.clone(), &mut arg_values, functions)?;
+                        let result = vm(func.prog.clone(), locals, functions)?;
+                        locals.extend(result.clone());
+                        //println!("result is: {:?}", result);
                         stack.extend(result);
                     } else {
                         return Err(format!("Function '{}' not found", label));
@@ -197,6 +200,7 @@ fn vm(
                     name: name.to_string(),
                     args: args.to_vec(),
                     prog: func_prog.to_vec(),
+                    locals: None,
                 };
                 functions.push(func);
                 pc += 1;
@@ -215,94 +219,3 @@ pub fn run(ast: Ast, lexer: &dyn NonStreamingLexer<DefaultLexeme<u32>, u32>) -> 
     let res = vm(prog.unwrap(), &mut locals, &mut functions);
     res.unwrap()
 }
-
-// #[cfg(test)]
-// mod test {
-//     use lrlex::lrlex_mod;
-//     use lrpar::lrpar_mod;
-//     lrlex_mod!("lib/ukiyo.l");
-//     lrpar_mod!("lib/ukiyo.y");
-
-//     use crate::vm::run;
-
-//     fn compile_and_run(input: &str) -> String {
-//         let lexerdef = ukiyo_l::lexerdef();
-//         let lexer = lexerdef.lexer(input);
-//         let res = ukiyo_y::parse(&lexer).0.unwrap().unwrap();
-//         let output = run(res, &lexer);
-//         let mut res_str = String::new();
-//         for element in output.iter() {
-//             res_str.push_str(&format!("[{}] ", element));
-//         }
-//         res_str.trim_end().to_string()
-//     }
-//     #[test]
-//     fn str_test() {
-//         assert_eq!(compile_and_run("\"\""), "[]");
-//         assert_eq!(compile_and_run("\"hello\""), "[hello]");
-//         assert_eq!(
-//             compile_and_run("let a = \"Hello, World!\" ; let b = a; print(b);"),
-//             "[Hello, World!]"
-//         );
-//         assert_eq!(
-//             compile_and_run(
-//                 "let a = \"Hello, World!\" ; let i = 0; while (i < 2) { print(a); let i = i + 1;}"
-//             ),
-//             "[Hello, World!] [Hello, World!]"
-//         );
-//     }
-//     #[test]
-//     fn basic() {
-//         assert_eq!(compile_and_run("2+3;"), "[5]");
-//         assert_eq!(compile_and_run("2+3+4;"), "[9]");
-//         assert_eq!(compile_and_run("2 + -3;"), "[-1]");
-//         assert_eq!(compile_and_run("2 - 3"), "[-1]");
-//         assert_eq!(compile_and_run("2 <= 3"), "[true]");
-//     }
-//     #[test]
-//     fn print_test() {
-//         assert_eq!(compile_and_run("let a = 1; let a = 2; let b = a + 3; print(b);"), "[5]");
-//         assert_eq!(compile_and_run("let a = 4; let b = 2; let a = b + 3; print(a);"), "[5]");
-//         assert_eq!(
-//             compile_and_run("let a = 1; let b = 2; let a = b + 3; print(a); print(b);"),
-//             "[5] [2]"
-//         );
-//         assert_eq!(
-//             compile_and_run(
-//                 "let a = 1; let a = 2; let b = a + 3; let z = a + b; print(z); print(b);"
-//             ),
-//             "[7] [5]"
-//         );
-//     }
-//     #[test]
-//     fn if_statement() {
-//         assert_eq!(compile_and_run("let a = 1; let b = 2; if(a < b) { print(a); }"), "[1]");
-//     }
-//     #[test]
-//     fn while_loop_test() {
-//         // assert_eq!(
-//         //     compile_and_run(
-//         //         "let z = 0; while (z < 1) {print(z); let z = z + 1; print(z); }
-//         //         "
-//         //     ),
-//         //     "[0] [1]"
-//         // );
-//         // assert_eq!(
-//         //     compile_and_run(
-//         //         "let x = 0; let y = 5  while (x < y) {print(x); let x = x + 1; print(y); let y = y - x; }
-//         //         "
-//         //     ),
-//         //     "[0] [5] [1] [4]"
-//         // );
-
-//         assert_eq!(
-//             compile_and_run("let x = 2; let y = 1; while (x < y ) {print(1); }
-//                 "),
-//             ""
-//         );
-//         // assert_eq!(
-//         //     compile_and_run("let x = 2; let y = 2; while (x == y) { print(0); let y = y + 1; }"),
-//         //     "[0]"
-//         // )
-//     }
-// }


### PR DESCRIPTION
Changes:
1. `args` is now of `Vec<String>` type, changed the grammar and `FuncDef` (in `compiler.rs`) to handle this.
2.  shifted `locals` and `Functions` vector to pass as an argument in `vm.rs` to avoid reinitialization.
3. Removed `cfg[test]` from `vm.rs`