### PR TITLE
Added support for function return statements in opcode and Expr struct.

### DIFF
--- a/src/lib/compiler.rs
+++ b/src/lib/compiler.rs
@@ -284,5 +284,12 @@ fn compiler_expr(
             res.push(OpCode::Call(func_name));
             res
         }
+
+        config_ast::Expr::Return { span: _, expr } => {
+            let mut res = Vec::new();
+            res.extend(compiler_expr(&*expr, lexer, locals, bc));
+            res.push(OpCode::Return);
+            res
+        }
     }
 }

--- a/src/lib/config_ast.rs
+++ b/src/lib/config_ast.rs
@@ -49,6 +49,10 @@ pub enum Expr {
         name: Span,
         params: Vec<Expr>,
     },
+    Return {
+        span: Span,
+        expr: Box<Expr>,
+    },
 }
 
 impl Expr {
@@ -65,6 +69,7 @@ impl Expr {
             Expr::Prog { span, .. } => *span,
             Expr::FuncDef { span, .. } => *span,
             Expr::Call { span, .. } => *span,
+            Expr::Return { span, .. } => *span,
         }
     }
 }

--- a/src/lib/ukiyo.l
+++ b/src/lib/ukiyo.l
@@ -21,6 +21,7 @@ let "LET"
 print "PRINT"
 if "IF"
 else "ELSE"
+return "RETURN"
 
 [0-9]+ "INT"
 [a-zA-Z_][a-zA-Z0-9_]*  "IDENTIFIER"

--- a/src/lib/ukiyo.y
+++ b/src/lib/ukiyo.y
@@ -2,6 +2,7 @@
 %%
 prog -> Result<Vec<Expr>, ()>: 
             prog statement { flattenr($1, $2) }
+          | return_statement { Ok(vec![$1?]) }
           | statement { Ok(vec![$1?]) }
           ;
 
@@ -67,8 +68,13 @@ while_loop -> Result<Expr, ()>:
 
 body -> Result<Expr, ()>:
         "LBRACE" prog "RBRACE" { Ok(Expr::Prog { span: $span, stmts: $2?}) }
+      | return_statement { $1 }
         ;
-          
+
+return_statement -> Result<Expr, ()>:
+                      "RETURN" binary_expression "SEMICOLON" {
+                           Ok(Expr::Return { span: $span, expr: Box::new($2?)})
+                      };          
 
 assigment -> Result<Expr, ()>: 
           "LET" "IDENTIFIER" "EQ" binary_expression {  

--- a/tests/files/return_stmt.ukiyo
+++ b/tests/files/return_stmt.ukiyo
@@ -1,0 +1,16 @@
+// Run-time:
+//   stdout:
+//     8
+//     ...
+
+func simple_return(x, y) {
+	return x+y;
+}
+
+func call() {
+	let x = 5;
+	let y = 3;
+    print(simple_return(x, y));
+}
+
+call();


### PR DESCRIPTION
Changes:
1.  Updated `ukiyo.l` and 'ukiyo.y` files to have `return` keyword and production rule.
2. Added `return` variant to `Expr` in `config_ast.rs`.
3. Added `tests/files/return_stmt.ukiyo` to check if opcode is working as intended.