### PR TITLE
Fixed jumps

### DIFF
--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -17,7 +17,7 @@ pub fn compile(contents: String) {
     }
     match res {
         Some(Ok(r)) => {
-            println!("{:?}", run(r, &lexer));
+            run(r, &lexer);
         }
         _ => eprintln!("Unable to evaluate expression."),
     }

--- a/src/lib/ukiyo.y
+++ b/src/lib/ukiyo.y
@@ -2,7 +2,6 @@
 %%
 prog -> Result<Vec<Expr>, ()>: 
             prog statement { flattenr($1, $2) }
-          | return_statement { Ok(vec![$1?]) }
           | statement { Ok(vec![$1?]) }
           ;
 
@@ -13,6 +12,7 @@ statement -> Result<Expr, ()>:
           | while_loop { $1 }
           | if_statement { $1 }
           | func_def { $1 }
+          | return_statement { $1 }
           ;
 
 func_call -> Result<Expr, ()>:
@@ -53,8 +53,8 @@ args -> Result<Vec<Span>, ()>:
        ;
         
 if_statement -> Result<Expr, ()>:
-                "IF" binary_expression body {
-                  Ok(Expr::IfStatement { span: $span, condition: Box::new($2?), body: Box::new($3?)})
+                "IF" "LBRACK" binary_expression "RBRACK"  body {
+                  Ok(Expr::IfStatement { span: $span, condition: Box::new($3?), body: Box::new($5?)})
                 };
 print_statement -> Result<Expr, ()>: 
                    "PRINT" "LBRACK" binary_expression "RBRACK" {  

--- a/src/lib/vm.rs
+++ b/src/lib/vm.rs
@@ -19,6 +19,17 @@ pub struct Function {
     pub prog: Vec<OpCode>,
 }
 
+impl Function {
+    pub fn new(name: String, args: Vec<String>, prog: Vec<OpCode>) -> Self {
+        Self {
+            name,
+            locals: None,
+            args,
+            prog,
+        }
+    }
+}
+
 impl Types {
     fn pretty(&self) -> String {
         match *self {
@@ -46,9 +57,7 @@ fn vm(
     }
     let mut pc = 0;
     let mut stack: Vec<Types> = Vec::new();
-    //initialize with exact size for locals.
-    //let mut locals: Vec<Types> = Vec::new();
-    //let mut functions: Vec<Function> = Vec::new();
+
     while pc < prog.len() {
         let expr = &prog[pc];
         match &*expr {
@@ -175,8 +184,6 @@ fn vm(
                 let val = stack.pop().unwrap();
 
                 if let Types::Bool(false) = val {
-                    //panic!();
-                    //assert!(*pos != usize::max_value());
                     pc = *pos;
                 } else {
                     pc += 1;
@@ -198,6 +205,9 @@ fn vm(
                 functions.push(func);
                 pc += 1;
             }
+            OpCode::Patch => {
+                unreachable!("Unabled to patch back value");
+            }
         }
     }
     Ok(stack)
@@ -205,8 +215,6 @@ fn vm(
 
 pub fn run(ast: Ast, lexer: &dyn NonStreamingLexer<DefaultLexeme<u32>, u32>) -> Vec<Types> {
     let prog = compiler(ast, lexer);
-    dbg!(&prog);
-    //panic!();
     let mut locals = Vec::new();
     let mut functions: Vec<Function> = Vec::new();
     let res = vm(prog.unwrap(), &mut locals, &mut functions);

--- a/tests/files/simple_while.ukiyo
+++ b/tests/files/simple_while.ukiyo
@@ -1,0 +1,13 @@
+// Run-time:
+//   stdout:
+//     0
+//     1
+//     2
+//     3
+//     4
+
+let i = 0;
+while (i < 5) {
+    print(i);
+    let i = i + 1;
+}

--- a/tests/files/while_in_func.ukiyo
+++ b/tests/files/while_in_func.ukiyo
@@ -1,0 +1,21 @@
+// Run-time:
+//   stdout:
+//     printing value of x
+//     4
+
+func while_test(y) {
+    while (y < 3) {
+        let y = y + 1;
+    }
+}
+func call() {
+    let x = 0;
+    while (x < 3) {
+        while_test(x);
+        let x = x + 1;
+    }
+    print("printing value of x"); 
+    print(x);
+}
+
+call();


### PR DESCRIPTION
This commit fixes a bug in the `Jump` bytecode, where jump locations weren't calculated correctly leading to wrong execution behaviour. While we are here also optimise the compiler by passing around the `bc` vector as a reference instead of copying it each time.

Changes:
1. `compiler.rs` : 
                 a) uses `bc` vector as reference instead of copying it each time in `Expr` variant match arm.
                 b) uses `OpCode::Patch` instead of two jumps.
2. `ukiyo.rs`:
                 a) changed syntax of how `if` should be called (basically now we need `(` and `)` around expresions.
3. Added test files to check if while loops are working fine.