### PR TITLE
Fixed OpCode::Call to support recursion and added test for it.

### DIFF
--- a/src/lib/compiler.rs
+++ b/src/lib/compiler.rs
@@ -115,7 +115,6 @@ fn compiler_expr(
         } => {
             compiler_expr(&expr, lexer, locals, bc);
             let idx_str = lexer.span_str(*id).to_string();
-
             match locals.iter().position(|x| x == &idx_str) {
                 Some(x) => bc.push(OpCode::StoreVar(x)),
                 None => {

--- a/src/lib/vm.rs
+++ b/src/lib/vm.rs
@@ -100,7 +100,6 @@ fn vm(
                             Types::String(x) => output.push_str(&x),
                             Types::NoneType => output.push_str("None"),
                         }
-                        stack.push(val_copy);
                     }
 
                     println!("{}", output);
@@ -108,12 +107,12 @@ fn vm(
                     // search for the user-defined function
                     let func = functions.iter().find(|f| f.name == *label);
                     if let Some(func) = func {
+                        let mut localsnew = Vec::new();
                         for arg in func.args.iter() {
                             let val = stack.pop().unwrap();
-                            locals.push(val);
+                            localsnew.push(val);
                         }
-                        let result = vm(func.prog.clone(), locals, functions)?;
-                        locals.extend(result.clone());
+                        let result = vm(func.prog.clone(), &mut localsnew, functions)?;
                         stack.extend(result);
                     } else {
                         return Err(format!("Function '{}' not found", label));

--- a/tests/files/fibonacci.ukiyo
+++ b/tests/files/fibonacci.ukiyo
@@ -1,0 +1,28 @@
+// Run-time:
+//   stdout:
+//      0
+//      1
+//      1
+//      2
+//      3
+//      5
+//      8
+//      13
+//      21
+//      34  
+
+func fib(n) {
+    if (n <= 1) {
+        return n;
+    }
+    return fib(n-1) + fib(n-2);
+}
+func call() {
+    let x = 0;
+    while (x < 10) {
+        print(fib(x));
+        let x = x + 1;
+    }
+}
+
+call();

--- a/tests/files/while_in_func.ukiyo
+++ b/tests/files/while_in_func.ukiyo
@@ -1,7 +1,7 @@
 // Run-time:
 //   stdout:
 //     printing value of x
-//     4
+//     3
 
 func while_test(y) {
     while (y < 3) {


### PR DESCRIPTION
1. In `vm.rs`:
       a) `OpCode::Call` now uses new local vector to push back result into stack. This is to avoid pushing back instructions on 
             existing locals.
      b)   Added file `tests/files/fibonacci.ukiyo` to test recursion works.