### PR TITLE
Function definition can be assigned to variable.

### DIFF
--- a/src/lib/config_ast.rs
+++ b/src/lib/config_ast.rs
@@ -40,7 +40,7 @@ pub enum Expr {
     },
     FuncDef {
         span: Span,
-        name: Span,
+        name: Option<Span>,
         args_list: Vec<Span>,
         body: Box<Expr>,
     },

--- a/tests/files/func_local.ukiyo
+++ b/tests/files/func_local.ukiyo
@@ -1,0 +1,17 @@
+// Run-time:
+//   stdout:
+//     2
+//
+
+func foo() {
+    return func (a, b) {
+        return a + b;
+    }
+}
+
+func main() {
+    let f = foo();
+    print(f(5,-3));
+}
+
+main();

--- a/tests/files/inline_func.ukiyo
+++ b/tests/files/inline_func.ukiyo
@@ -1,0 +1,14 @@
+// Run-time:
+//   stdout:
+//     3
+//
+
+func foo() {
+    let a = 1; let b = 2;
+    let fn = func(a, b) {
+        return a + b;
+    };
+    let x = fn(a, b);
+    print(x);
+}
+foo();


### PR DESCRIPTION
Major changes:
1.`vm.rs` has:
         a)  seperate `OpCode::InlineFunc` for defining anonymous functions.
         b) `Call` match considers 3 cases: finding target in `function`, `locals` and `label`. 
         c)  extended `StoreVar` match arm to store `String` as well. Later I'll add support for storing functions in variable too. 
               but I feel that should be seperate PR.
2). `compiler.rs` has:
        a) `CallTarget` enum to seperate choices between `functions`, anon function assigned to variables, and `label` such as  
              `print`.
        b) `FuncDef` now handles cases for `InlineFunc`.
3) `ukiyo.rs` has:
        a) grammar addition for annon function.
4) Added test file `inline_func.ukiyo`